### PR TITLE
etl: add cluster-level resource defaults and limits for ETL pods

### DIFF
--- a/cmn/config.go
+++ b/cmn/config.go
@@ -103,6 +103,7 @@ type (
 		Ext         any             `json:"ext,omitempty"`              // reserved
 		Tracing     *TracingConf    `json:"tracing,omitempty"`          // see cmn/gco fixup; build tag
 		Dsort       *DsortConf      `json:"distributed_sort,omitempty"` // ditto; build tag
+		ETL         ETLConf         `json:"etl"`                        // cluster-level ETL resource defaults & limits
 		Auth        AuthConf        `json:"auth" allow:"cluster"`       // ditto
 		Backend     BackendConf     `json:"backend" allow:"cluster"`
 		WritePolicy WritePolicyConf `json:"write_policy"` // object metadata: (immediate | delayed | never)
@@ -162,6 +163,7 @@ type (
 		Keepalive   *KeepaliveConfToSet   `json:"keepalivetracker,omitempty"`
 		Downloader  *DownloaderConfToSet  `json:"downloader,omitempty"`
 		Dsort       *DsortConfToSet       `json:"distributed_sort,omitempty"`
+		ETL         *ETLConfToSet         `json:"etl,omitempty"`
 		Transport   *TransportConfToSet   `json:"transport,omitempty"`
 		Memsys      *MemsysConfToSet      `json:"memsys,omitempty"`
 		TCB         *TCBConfToSet         `json:"tcb,omitempty"`
@@ -334,6 +336,24 @@ type (
 	TraceExporterAuthConfToSet struct {
 		TokenHeader *string `json:"token_header,omitempty"` // header used to pass exporter auth token
 		TokenFile   *string `json:"token_file,omitempty"`   // filepath from where auth token can be obtained
+	}
+
+	// ETLConf defines cluster-level resource defaults and limits for ETL pods.
+	// When enabled, any ETL init request that omits resource specifications will
+	// have the defaults applied; requests that exceed the maximum limits are rejected.
+	ETLConf struct {
+		MaxCPU        string `json:"max_cpu,omitempty"`        // max CPU limit per ETL pod, e.g. "30" (cores)
+		MaxMemory     string `json:"max_memory,omitempty"`     // max memory limit per ETL pod, e.g. "10Gi"
+		DefaultCPU    string `json:"default_cpu,omitempty"`    // default CPU for ETL pod when not specified
+		DefaultMemory string `json:"default_memory,omitempty"` // default memory for ETL pod when not specified
+		Enabled       bool   `json:"enabled"`                  // feature toggle; disabled by default
+	}
+	ETLConfToSet struct {
+		MaxCPU        *string `json:"max_cpu,omitempty"`
+		MaxMemory     *string `json:"max_memory,omitempty"`
+		DefaultCPU    *string `json:"default_cpu,omitempty"`
+		DefaultMemory *string `json:"default_memory,omitempty"`
+		Enabled       *bool   `json:"enabled,omitempty"`
 	}
 
 	// NOTE: StatsTime is one important timer - a pulse
@@ -1035,6 +1055,7 @@ var (
 	_ validator = (*WritePolicyConf)(nil)
 	_ validator = (*TracingConf)(nil)
 	_ validator = (*GetBatchConf)(nil)
+	_ validator = (*ETLConf)(nil)
 
 	_ validator = (*feat.Flags)(nil) // is called explicitly from main config validator
 
@@ -2565,6 +2586,18 @@ func (c *TracingConf) Validate() error {
 			return nil
 		}
 		c.SamplerProbability = prob
+	}
+	return nil
+}
+
+func (c *ETLConf) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	// actual resource-quantity parsing/validation is done in ext/etl (K8s dependencies)
+	// here we only check that if max is set, default must not be empty and vice versa
+	if c.MaxCPU == "" && c.DefaultCPU == "" && c.MaxMemory == "" && c.DefaultMemory == "" {
+		return errors.New("etl: enabled but no resource limits or defaults configured")
 	}
 	return nil
 }

--- a/ext/etl/boot.go
+++ b/ext/etl/boot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/NVIDIA/aistore/core"
 
 	corev1 "k8s.io/api/core/v1"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -395,4 +396,81 @@ func (b *etlBootstrapper) _getTargetPodSpec() (*corev1.PodSpec, error) {
 		return nil, fmt.Errorf("failed to get target pod %q: %w", b.targetPodName, err)
 	}
 	return &targetPod.Spec, nil
+}
+
+// enforceResources applies cluster-level ETL resource defaults and rejects requests
+// that exceed the configured maximum limits (when the feature is enabled).
+func (b *etlBootstrapper) enforceResources() error {
+	etlConf := &b.config.ETL
+	if !etlConf.Enabled {
+		return nil
+	}
+
+	containers := b.pod.Spec.Containers
+	if len(containers) == 0 {
+		return nil
+	}
+	c := &containers[0]
+
+	// Apply defaults when not specified
+	if etlConf.DefaultCPU != "" {
+		q := k8sresource.MustParse(etlConf.DefaultCPU)
+		if _, ok := c.Resources.Requests[corev1.ResourceCPU]; !ok {
+			if c.Resources.Requests == nil {
+				c.Resources.Requests = make(corev1.ResourceList)
+			}
+			c.Resources.Requests[corev1.ResourceCPU] = q
+		}
+		if _, ok := c.Resources.Limits[corev1.ResourceCPU]; !ok {
+			if c.Resources.Limits == nil {
+				c.Resources.Limits = make(corev1.ResourceList)
+			}
+			c.Resources.Limits[corev1.ResourceCPU] = q
+		}
+	}
+	if etlConf.DefaultMemory != "" {
+		q := k8sresource.MustParse(etlConf.DefaultMemory)
+		if _, ok := c.Resources.Requests[corev1.ResourceMemory]; !ok {
+			if c.Resources.Requests == nil {
+				c.Resources.Requests = make(corev1.ResourceList)
+			}
+			c.Resources.Requests[corev1.ResourceMemory] = q
+		}
+		if _, ok := c.Resources.Limits[corev1.ResourceMemory]; !ok {
+			if c.Resources.Limits == nil {
+				c.Resources.Limits = make(corev1.ResourceList)
+			}
+			c.Resources.Limits[corev1.ResourceMemory] = q
+		}
+	}
+
+	// Enforce maximum limits
+	if etlConf.MaxCPU != "" {
+		maxCPU := k8sresource.MustParse(etlConf.MaxCPU)
+		if req, ok := c.Resources.Requests[corev1.ResourceCPU]; ok {
+			if req.Cmp(maxCPU) > 0 {
+				return cmn.NewErrETLf(b.errCtx, "requested CPU %s exceeds cluster limit %s", req.String(), maxCPU.String())
+			}
+		}
+		if lim, ok := c.Resources.Limits[corev1.ResourceCPU]; ok {
+			if lim.Cmp(maxCPU) > 0 {
+				return cmn.NewErrETLf(b.errCtx, "CPU limit %s exceeds cluster limit %s", lim.String(), maxCPU.String())
+			}
+		}
+	}
+	if etlConf.MaxMemory != "" {
+		maxMem := k8sresource.MustParse(etlConf.MaxMemory)
+		if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+			if req.Cmp(maxMem) > 0 {
+				return cmn.NewErrETLf(b.errCtx, "requested memory %s exceeds cluster limit %s", req.String(), maxMem.String())
+			}
+		}
+		if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+			if lim.Cmp(maxMem) > 0 {
+				return cmn.NewErrETLf(b.errCtx, "memory limit %s exceeds cluster limit %s", lim.String(), maxMem.String())
+			}
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Adds ETLConf to cluster config with default/max CPU and memory for ETL pods. Disabled by default.