### PR TITLE
replace deprecated add_event_handler with lifespan context manager

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,131 @@
+# AIStore Development Guide
+
+## What is AIStore?
+
+AIStore (AIS) is a lightweight distributed storage system for AI workloads providing:
+- Multi-cloud unified access (AWS S3, GCS, Azure, OCI)
+- Linear scalability with elastic cluster runtime growth
+- High-performance I/O with no routing overhead
+- AI-optimized features: sharding, ETL, batch ops, PyTorch integration
+
+**Architecture**: Proxy nodes (gateways) + Target nodes (storage) with distributed metadata consensus.
+
+## Tech Stack
+
+**Languages**: Go 1.25 (daemon, CLI), Python 3.x (SDK, PyTorch)
+**Key Deps**: AWS/GCP/Azure SDKs, fasthttp, msgp, k8s.io/client-go, reedsolomon, Prometheus
+**Build Tags**: `aws`, `gcp`, `azure`, `oci`, `debug`, `mono`, `nethttp`, `oteltracing`
+
+## Project Structure
+
+```
+ais/ Main daemon (proxy.go, target.go, htrun.go, metasync, txn)
+core/ Interfaces (Node, Target, Backend, LOM), meta/
+cmn/ Config, utilities, cos/ (errors, time), nlog/
+api/ Go client API, apc/ (constants), env/
+cmd/ Binaries: aisnode, cli, aisloader, authn, ishard, xmeta
+python/ SDK (aistore/sdk/), PyTorch, boto3 patch
+transport/ High-perf object streaming with callbacks
+fs/ Mountpath mgmt, health checker (FSHC)
+ext/ Extensions: dsort, etl
+xact/ Async batch jobs (rebalance, EC, mirror, prefetch)
+deploy/ Local/K8s configs, dev/local/ scripts
+docs/ Markdown docs
+bench/ Benchmarking tools
+scripts/ Build/test/CI automation
+```
+
+## Essential Commands
+
+### Build
+```bash
+make node # Build aisnode daemon
+TAGS="aws gcp" make node # With cloud backends
+make cli # Build CLI (static binary)
+make all # Build all (node, cli, authn, aisloader)
+MODE=debug make node # Debug build with symbols
+```
+
+### Local Dev Cluster
+```bash
+make deploy # Interactive prompts
+make kill deploy <<< $'7\n2\n4\ny\ny\n' # 7 targets, 2 proxies, 4 mountpaths
+TAGS="aws gcp" make kill deploy <<< $'5\n1\n' # With backends
+make run # Use existing configs
+make restart # Kill + run
+make kill # Stop cluster
+make clean # Full cleanup
+```
+
+### Testing
+```bash
+BUCKET=tmp make test-short # Short tests (~10 min)
+BUCKET=mybucket make test-long # Full integration
+RE="TestETL" BUCKET=tmp make test-run # Specific test
+BUCKET=tmp make ci # Lint + spell + short tests
+GORACE='log_path=/tmp/race' make deploy # With race detector
+cd cmd/cli && go test -v -tags=debug ./... # CLI tests
+cd python && pytest tests/ # Python tests
+```
+
+### Linting
+```bash
+make lint-update # Install golangci-lint
+make lint # Go linter
+make lint-python # Python linter
+make fmt-check # Format check
+make fmt-fix # Auto-format
+make spell-check # Spell checker
+```
+
+### Profiling
+```bash
+MEM_PROFILE=/tmp/mem make deploy # Memory profiling (needs graceful shutdown)
+CPU_PROFILE=/tmp/cpu make deploy # CPU profiling
+```
+
+## Key File References
+
+**Startup**: `cmd/aisnode/main.go:21`, `ais/proxy.go:130`, `ais/target.go:90`, `ais/earlystart.go:100`
+**HTTP**: `ais/http.go:30` (handlers), `ais/proxy.go:250` (routes), `ais/target.go:400`, `ais/prxs3.go`, `ais/tgts3.go`
+**Metadata**: `cmn/gco.go:20` (config), `ais/bucketmeta.go:55` (BMD), `ais/clustermap.go:58` (Smap), `ais/metasync.go:112` (REVS)
+**Objects**: `ais/tgtobj.go:200` (PUT), `ais/tgtobj.go:600` (GET), `core/lom.go` (Local Object Metadata)
+**Batch**: `ais/prxtxn.go:55` (2PC), `xact/xs/xs.go` (framework), `ais/prxdl.go`(download)
+
+## Additional Documentation
+
+`.claude/docs/architectural_patterns.md` - Design patterns: interfaces, metadata ownership, messaging, transactions, concurrency, error handling, config mgmt, callbacks
+
+**Core Docs** (in `docs/`):
+- `overview.md` - Architecture, terminology, diagrams, xactions
+- `bucket.md` - Bucket identity, properties, lifecycle
+- `networking.md` - Network separation, IPv6, multi-homing
+- `batch.md` - 30+ batch operations, xaction lifecycle
+- `etl.md` - ETL framework, transforms
+- `performance.md` - Tuning guides
+- `cli.md` - CLI reference
+- `python_sdk.md` - Python SDK guide
+- `getting_started.md` - Quick start, deployment options
+
+**Component READMEs**: `cmd/cli/`, `cmd/ishard/`, `python/aistore/sdk/`, `python/aistore/pytorch/`, `transport/`, `CONTRIBUTING.md`
+
+## Common Workflows
+
+**Add Bucket Property**: Modify `cmn.Bprops` (`cmn/api.go`) → validate (`cmn/config.go`) → update BMD (`ais/bucketmeta.go`) → handlers (`ais/prxbck.go`, `ais/tgtbck.go`) → CLI (`cmd/cli/cli/`) → tests
+
+**Add Backend Provider**: Implement `core.Backend` (`ais/backend/`) → register (`ais/target.go:initBackends()`) → add constant (`api/apc/provider.go`) → docs
+
+**Add Xaction**: Define in `xact/xs/` or `xact/xreg/` → implement `xact.Snap` → register (`xact/xreg/xreg.go`) → CLI command
+
+**Debug**: `ais config cluster log.level=4`, use `MODE=debug` builds, `ais log show`, `xmeta -in <path>`, trace `[TID]` in logs
+
+## Python Code Style
+
+- **Docstring args**: Always include the type — `param_name (type): description`. E.g., `node_id (str): Daemon ID` not `node_id: Daemon ID`.
+- **Docstrings**: Use single backticks (`` ` ``) for inline code references, not double backticks.
+
+## Git & Commit Rules
+
+- **Commit messages**: Lowercase first word in summary line (e.g. `transformers: bump ...`), then concise bullet points. Never include `Co-Authored-By` lines. Always use `git commit -s` for the `Signed-off-by` line — never write it manually. Always spell-check the commit message before committing and when reviewing MRs.
+- **Never push** to any remote without explicitly asking the user first.
+- **GitLab commits** require a `Signed-off-by` line (use `git commit -s`).

--- a/cmn/config_etl_test.go
+++ b/cmn/config_etl_test.go
@@ -1,0 +1,126 @@
+// Package cmn provides common low-level types and utilities for all aistore projects.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package cmn_test
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aistore/cmn"
+)
+
+func TestETLConfValidateDisabled(t *testing.T) {
+	// Disabled config should always pass validation, even with empty fields
+	c := cmn.ETLConf{Enabled: false}
+	if err := c.Validate(); err != nil {
+		t.Errorf("disabled ETLConf should validate: %v", err)
+	}
+}
+
+func TestETLConfValidateDefaults(t *testing.T) {
+	// Valid config with all fields set
+	c := cmn.ETLConf{
+		Enabled:       true,
+		MaxCPU:        "4",
+		MaxMemory:     "8Gi",
+		DefaultCPU:    "1",
+		DefaultMemory: "512Mi",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("valid ETLConf should validate: %v", err)
+	}
+}
+
+func TestETLConfValidateDefaultsExceedMax(t *testing.T) {
+	// Default CPU exceeds max CPU — should fail
+	c := cmn.ETLConf{
+		Enabled:       true,
+		MaxCPU:        "2",
+		MaxMemory:     "8Gi",
+		DefaultCPU:    "4",
+		DefaultMemory: "512Mi",
+	}
+	if err := c.Validate(); err == nil {
+		t.Error("ETLConf with default_cpu > max_cpu should fail validation")
+	}
+
+	// Default memory exceeds max memory — should fail
+	c = cmn.ETLConf{
+		Enabled:       true,
+		MaxCPU:        "4",
+		MaxMemory:     "1Gi",
+		DefaultCPU:    "1",
+		DefaultMemory: "2Gi",
+	}
+	if err := c.Validate(); err == nil {
+		t.Error("ETLConf with default_memory > max_memory should fail validation")
+	}
+}
+
+func TestETLConfValidateInvalidQuantities(t *testing.T) {
+	tests := []struct {
+		name string
+		conf cmn.ETLConf
+	}{
+		{
+			name: "invalid max_cpu",
+			conf: cmn.ETLConf{Enabled: true, MaxCPU: "not-a-cpu", MaxMemory: "1Gi", DefaultCPU: "1", DefaultMemory: "512Mi"},
+		},
+		{
+			name: "invalid max_memory",
+			conf: cmn.ETLConf{Enabled: true, MaxCPU: "4", MaxMemory: "bad", DefaultCPU: "1", DefaultMemory: "512Mi"},
+		},
+		{
+			name: "invalid default_cpu",
+			conf: cmn.ETLConf{Enabled: true, MaxCPU: "4", MaxMemory: "1Gi", DefaultCPU: "xyz", DefaultMemory: "512Mi"},
+		},
+		{
+			name: "invalid default_memory",
+			conf: cmn.ETLConf{Enabled: true, MaxCPU: "4", MaxMemory: "1Gi", DefaultCPU: "1", DefaultMemory: "abc"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.conf.Validate(); err == nil {
+				t.Errorf("%s: expected validation error for invalid quantity", tt.name)
+			}
+		})
+	}
+}
+
+func TestETLConfValidatePartialFields(t *testing.T) {
+	// Only max fields set (no defaults) — should be valid
+	c := cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("ETLConf with only max fields should validate: %v", err)
+	}
+
+	// Only default fields set (no max) — should be valid
+	c = cmn.ETLConf{
+		Enabled:       true,
+		DefaultCPU:    "1",
+		DefaultMemory: "512Mi",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("ETLConf with only default fields should validate: %v", err)
+	}
+}
+
+func TestETLConfValidateMilliCPU(t *testing.T) {
+	// Milli-CPU values (e.g., "500m")
+	c := cmn.ETLConf{
+		Enabled:       true,
+		MaxCPU:        "2000m",
+		MaxMemory:     "4Gi",
+		DefaultCPU:    "500m",
+		DefaultMemory: "256Mi",
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("ETLConf with milli-CPU should validate: %v", err)
+	}
+}

--- a/ext/etl/resource_test.go
+++ b/ext/etl/resource_test.go
@@ -1,0 +1,382 @@
+// Package etl provides ETL (Extract-Transform-Load) protocol support.
+/*
+ * Copyright (c) 2018-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+package etl
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/aistore/cmn"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+//
+// applyETLResourceDefaults
+//
+
+func TestApplyDefaultsNoContainers(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:       true,
+		DefaultCPU:    "1",
+		DefaultMemory: "512Mi",
+	}
+	pod := &corev1.Pod{}
+	applyETLResourceDefaults(pod, etlConf)
+	// No containers — should not panic
+	if len(pod.Spec.Containers) != 0 {
+		t.Error("expected no containers")
+	}
+}
+
+func TestApplyDefaultsEmptyResources(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:       true,
+		DefaultCPU:    "1",
+		DefaultMemory: "512Mi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "transform"},
+			},
+		},
+	}
+	applyETLResourceDefaults(pod, etlConf)
+
+	res := pod.Spec.Containers[0].Resources
+	// Check requests
+	cpuReq := res.Requests[corev1.ResourceCPU]
+	if cpuReq.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("expected CPU request '1', got %s", cpuReq.String())
+	}
+	memReq := res.Requests[corev1.ResourceMemory]
+	if memReq.Cmp(resource.MustParse("512Mi")) != 0 {
+		t.Errorf("expected memory request '512Mi', got %s", memReq.String())
+	}
+	// Check limits
+	cpuLim := res.Limits[corev1.ResourceCPU]
+	if cpuLim.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("expected CPU limit '1', got %s", cpuLim.String())
+	}
+	memLim := res.Limits[corev1.ResourceMemory]
+	if memLim.Cmp(resource.MustParse("512Mi")) != 0 {
+		t.Errorf("expected memory limit '512Mi', got %s", memLim.String())
+	}
+}
+
+func TestApplyDefaultsPreservesExisting(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:       true,
+		DefaultCPU:    "1",
+		DefaultMemory: "512Mi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU: resource.MustParse("2"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	applyETLResourceDefaults(pod, etlConf)
+
+	res := pod.Spec.Containers[0].Resources
+	// Existing CPU request should be preserved
+	cpuReq := res.Requests[corev1.ResourceCPU]
+	if cpuReq.Cmp(resource.MustParse("2")) != 0 {
+		t.Errorf("existing CPU request should be preserved, got %s", cpuReq.String())
+	}
+	// Missing memory request should get default
+	memReq := res.Requests[corev1.ResourceMemory]
+	if memReq.Cmp(resource.MustParse("512Mi")) != 0 {
+		t.Errorf("expected default memory request '512Mi', got %s", memReq.String())
+	}
+	// Existing memory limit should be preserved
+	memLim := res.Limits[corev1.ResourceMemory]
+	if memLim.Cmp(resource.MustParse("1Gi")) != 0 {
+		t.Errorf("existing memory limit should be preserved, got %s", memLim.String())
+	}
+	// Missing CPU limit should get default
+	cpuLim := res.Limits[corev1.ResourceCPU]
+	if cpuLim.Cmp(resource.MustParse("1")) != 0 {
+		t.Errorf("expected default CPU limit '1', got %s", cpuLim.String())
+	}
+}
+
+func TestApplyDefaultsOnlyDefaults(t *testing.T) {
+	// No defaults configured — should not modify
+	etlConf := &cmn.ETLConf{
+		Enabled: true,
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "transform"},
+			},
+		},
+	}
+	applyETLResourceDefaults(pod, etlConf)
+
+	res := pod.Spec.Containers[0].Resources
+	if len(res.Requests) != 0 {
+		t.Errorf("no defaults configured, requests should be empty, got %v", res.Requests)
+	}
+	if len(res.Limits) != 0 {
+		t.Errorf("no defaults configured, limits should be empty, got %v", res.Limits)
+	}
+}
+
+func TestApplyDefaultsMultipleContainers(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:       true,
+		DefaultCPU:    "500m",
+		DefaultMemory: "256Mi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "transform1"},
+				{Name: "transform2"},
+			},
+		},
+	}
+	applyETLResourceDefaults(pod, etlConf)
+
+	for i, c := range pod.Spec.Containers {
+		cpuReq := c.Resources.Requests[corev1.ResourceCPU]
+		if cpuReq.Cmp(resource.MustParse("500m")) != 0 {
+			t.Errorf("container %d: expected CPU request '500m', got %s", i, cpuReq.String())
+		}
+		memReq := c.Resources.Requests[corev1.ResourceMemory]
+		if memReq.Cmp(resource.MustParse("256Mi")) != 0 {
+			t.Errorf("container %d: expected memory request '256Mi', got %s", i, memReq.String())
+		}
+	}
+}
+
+//
+// validateETLResourceLimits
+//
+
+func TestValidateLimitsWithinBounds(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateETLResourceLimits(pod, etlConf); err != nil {
+		t.Errorf("resources within limits should pass: %v", err)
+	}
+}
+
+func TestValidateLimitsExceedCPU(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateETLResourceLimits(pod, etlConf); err == nil {
+		t.Error("CPU exceeding max should fail validation")
+	}
+}
+
+func TestValidateLimitsExceedMemory(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "1Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateETLResourceLimits(pod, etlConf); err == nil {
+		t.Error("memory exceeding max should fail validation")
+	}
+}
+
+func TestValidateLimitsNoMaxConfigured(t *testing.T) {
+	// No max limits set — should always pass
+	etlConf := &cmn.ETLConf{
+		Enabled: true,
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100"),
+							corev1.ResourceMemory: resource.MustParse("100Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validateETLResourceLimits(pod, etlConf); err != nil {
+		t.Errorf("no max configured, should pass: %v", err)
+	}
+}
+
+func TestValidateLimitsNoResources(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "transform"},
+			},
+		},
+	}
+	// No resources specified — should pass (nothing to validate against)
+	if err := validateETLResourceLimits(pod, etlConf); err != nil {
+		t.Errorf("no resources specified should pass: %v", err)
+	}
+}
+
+func TestValidateLimitsExactlyAtMax(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("8Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	// Exactly at max — should pass
+	if err := validateETLResourceLimits(pod, etlConf); err != nil {
+		t.Errorf("resources exactly at max should pass: %v", err)
+	}
+}
+
+func TestValidateLimitsRequestsExceedMax(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	// Requests exceeding max should also fail
+	if err := validateETLResourceLimits(pod, etlConf); err == nil {
+		t.Error("CPU requests exceeding max should fail validation")
+	}
+}
+
+func TestValidateLimitsMultipleContainers(t *testing.T) {
+	etlConf := &cmn.ETLConf{
+		Enabled:   true,
+		MaxCPU:    "4",
+		MaxMemory: "8Gi",
+	}
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "transform1",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("2"),
+							corev1.ResourceMemory: resource.MustParse("4Gi"),
+						},
+					},
+				},
+				{
+					Name: "transform2",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("8"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			},
+		},
+	}
+	// Second container exceeds CPU max
+	if err := validateETLResourceLimits(pod, etlConf); err == nil {
+		t.Error("second container exceeding max CPU should fail")
+	}
+}


### PR DESCRIPTION
FastAPI removed the add_event_handler method (inherited from Starlette) in recent versions, causing pylint E1101 no-member errors. Replaces with the recommended lifespan context manager pattern.